### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/hamidhusain851/4e456497-9c25-44b7-88ce-455cefb735ea/28b2068b-312d-4af6-9a35-0256e49d4b44/_apis/work/boardbadge/c63b0f8c-5136-4c1a-bc15-682ddaf81ca3)](https://dev.azure.com/hamidhusain851/4e456497-9c25-44b7-88ce-455cefb735ea/_boards/board/t/28b2068b-312d-4af6-9a35-0256e49d4b44/Microsoft.RequirementCategory)
 # Welcome to GitHub
 
 Welcome to GitHub—where millions of developers work together on software. Ready to get started? Let’s learn how this all works by building and publishing your first GitHub Pages website!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hamidhusain851/4e456497-9c25-44b7-88ce-455cefb735ea/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.